### PR TITLE
fix(project): Type definition of KeyValue is wrong

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -18,8 +18,8 @@ export function append(element: Element, node: SVGElement): typeof element;
  */
 export function appendTo(element: Element, target: SVGElement): typeof element;
 
-export interface KeyValue {
-  [key: string]: string | number;
+export interface KeyValue<TKey = string, TValue = any> {
+  [key: TKey]: TValue;
 }
 
 export function attr(node: SVGElement, name: string): string;


### PR DESCRIPTION
There are cases where the value is also a `number[]`. So we just default to `any`.