### PR TITLE
fix(project): lazily create the fake svg node instance on geometry helpers

### DIFF
--- a/lib/geometry.js
+++ b/lib/geometry.js
@@ -5,7 +5,15 @@
 import create from './create';
 
 // fake node used to instantiate svg geometry elements
-var node = create('svg');
+var node = null;
+
+function getNode() {
+  if (node === null) {
+    node = create('svg');
+  }
+
+  return node;
+}
 
 function extend(object, props) {
   var i, k, keys = Object.keys(props);
@@ -19,7 +27,7 @@ function extend(object, props) {
 
 
 export function createPoint(x, y) {
-  var point = node.createSVGPoint();
+  var point = getNode().createSVGPoint();
 
   switch (arguments.length) {
   case 0:
@@ -47,7 +55,7 @@ export function createPoint(x, y) {
  * @return {SVGMatrix}
  */
 export function createMatrix(a, b, c, d, e, f) {
-  var matrix = node.createSVGMatrix();
+  var matrix = getNode().createSVGMatrix();
 
   switch (arguments.length) {
   case 0:
@@ -68,8 +76,8 @@ export function createMatrix(a, b, c, d, e, f) {
 
 export function createTransform(matrix) {
   if (matrix) {
-    return node.createSVGTransformFromMatrix(matrix);
+    return getNode().createSVGTransformFromMatrix(matrix);
   } else {
-    return node.createSVGTransform();
+    return getNode().createSVGTransform();
   }
 }


### PR DESCRIPTION
Importing the geometry helpers module had the side-effect of immediately creating an svg node instance. This caused errors on Node.js just by importing the package, making it difficult to statically generate pages.
By lazily creating the fake svg node instance used to create svg geometry elements, we make the module pure, without side-effects until we actually call some method.

Closes #10.