### PR TITLE
fix: escape entities in attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [tiny-svg](https://github.com/bpmn-io/tiny-svg) are docum
 
 ___Note:__ Yet to be released changes appear here._
 
+## 4.1.3
+
+* `FIX`: escape entities in attributes ([#16](https://github.com/bpmn-io/tiny-svg/issues/16))
+
 ## 4.1.2
 
 * `CHORE`: make `clear` work standalone

--- a/lib/util/serialize.js
+++ b/lib/util/serialize.js
@@ -3,7 +3,7 @@
  */
 
 var TEXT_ENTITIES = /([&<>]{1})/g;
-var ATTR_ENTITIES = /([\n\r"]{1})/g;
+var ATTR_ENTITIES = /([&<>\n\r"]{1})/g;
 
 var ENTITY_REPLACEMENT = {
   '&': '&amp;',

--- a/test/spec/innerSVG.js
+++ b/test/spec/innerSVG.js
@@ -225,7 +225,7 @@ describe('inner-svg', function() {
       var container = createContainer();
       var element = appendTo(create('svg'), container);
 
-      var text = '<g><rect data-foo="1 &lt; 2"/></g>';
+      var text = '<g><rect data-foo="1 &lt;&gt; 2"/></g>';
 
       innerSVG(element, text);
 

--- a/test/spec/innerSVG.js
+++ b/test/spec/innerSVG.js
@@ -218,6 +218,41 @@ describe('inner-svg', function() {
       expect(svg).to.eql(text);
     });
 
+
+    it('should escape <> in attributes', function() {
+
+      // given
+      var container = createContainer();
+      var element = appendTo(create('svg'), container);
+
+      var text = '<g><rect data-foo="1 &lt; 2"/></g>';
+
+      innerSVG(element, text);
+
+      // when
+      var svg = innerSVG(element);
+
+      // then
+      expect(svg).to.eql(text);
+    });
+
+
+    it('should escape & in attributes', function() {
+
+      // given
+      var container = createContainer();
+      var element = appendTo(create('svg'), container);
+
+      var text = '<g><rect data-foo="1 &amp; 2"/></g>';
+
+      innerSVG(element, text);
+
+      // when
+      var svg = innerSVG(element);
+
+      // then
+      expect(svg).to.eql(text);
+    });
   });
 
 });


### PR DESCRIPTION
Closes #16

### Proposed Changes

This makes sure we handle properly SVGs like `<g data-attr="&gt;" />`.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
